### PR TITLE
Fix HTML doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JSON Schema Cheat Sheet with the most needed stuff..
 <br><br>
 
 # DOCS
-- https://json-schema.org/understanding-json-schema/index.html
+- https://json-schema.org/understanding-json-schema
 
 
 <br><br>


### PR DESCRIPTION
The previous link lead to error 400.

The updated link point to the same page.